### PR TITLE
Fixes: reconnect signature and multi address validation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,13 @@ class WebsocketStar {
       options = {}
     }
 
-    const listener = this.listeners_list[cleanUrlSIO(ma)]
+    let url
+    try {
+      url = cleanUrlSIO(ma)
+    } catch (err) {
+      return callback(err) // early
+    }
+    const listener = this.listeners_list[url]
     if (!listener) {
       callback(new Error('No listener for this server'))
       return new Connection()

--- a/src/listener.js
+++ b/src/listener.js
@@ -222,12 +222,16 @@ class Listener extends EE {
         return callback(err)
       } else this.log('success')
 
-      this.io.on('reconnect', this._crypto.bind(this, (err) => {
-        if (err) {
-          this.log('reconnect error', err)
-          this.emit('error', err)
-        } else this.log('reconnected')
-      }))
+      this.io.on('reconnect', () => {
+        // force to get a new signature
+        this.signature = null
+        this._crypto((err) => {
+          if (err) {
+            this.log('reconnect error', err)
+            this.emit('error', err)
+          } else this.log('reconnected')
+        })
+      })
 
       this.emit('listening')
       callback()


### PR DESCRIPTION
Two fixes on this PR:

1) when reconnecting, signature is forced to be regenerated. When reconnecting and using a local rendez-vous server, reusing the signature was somehow causing this:

```js
Error: Unknown wire type: 6
    at skip (/Users/pedroteixeira/projects/ipfs/js-libp2p-websocket-star-rendezvous/node_modules/protons/src/compile/decode.js:198:13)
    at Object.decode (/Users/pedroteixeira/projects/ipfs/js-libp2p-websocket-star-rendezvous/node_modules/protons/src/compile/decode.js:156:18)
    at Object.exports.unmarshalPublicKey (/Users/pedroteixeira/projects/ipfs/js-libp2p-websocket-star-rendezvous/node_modules/libp2p-crypto/src/keys/index.js:52:37)
    at Function.exports.createFromPubKey (/Users/pedroteixeira/projects/ipfs/js-libp2p-websocket-star-rendezvous/node_modules/peer-id/src/index.js:178:26)
    at Object.getIdAndValidate (/Users/pedroteixeira/projects/ipfs/js-libp2p-websocket-star-rendezvous/src/utils.js:103:6)
    at join (/Users/pedroteixeira/projects/ipfs/js-libp2p-websocket-star-rendezvous/src/routes.js:121:14)
    at Socket.<anonymous> (/Users/pedroteixeira/projects/ipfs/js-libp2p-websocket-star-rendezvous/src/utils.js:91:20)
    at emitThree (events.js:136:13)
    at Socket.emit (events.js:217:7)
    at /Users/pedroteixeira/projects/ipfs/js-libp2p-websocket-star-rendezvous/node_modules/socket.io/lib/socket.js:513:12
D Error: Crypto error
    at Id.createFromPubKey (/Users/pedroteixeira/projects/ipfs/js-libp2p-websocket-star-rendezvous/src/utils.js:106:17)
    at Function.exports.createFromPubKey (/Users/pedroteixeira/projects/ipfs/js-libp2p-websocket-star-rendezvous/node_modules/peer-id/src/index.js:180:12)
    at Object.getIdAndValidate (/Users/pedroteixeira/projects/ipfs/js-libp2p-websocket-star-rendezvous/src/utils.js:103:6)
    at join (/Users/pedroteixeira/projects/ipfs/js-libp2p-websocket-star-rendezvous/src/routes.js:121:14)
    at Socket.<anonymous> (/Users/pedroteixeira/projects/ipfs/js-libp2p-websocket-star-rendezvous/src/utils.js:91:20)
    at emitThree (events.js:136:13)
    at Socket.emit (events.js:217:7)
    at /Users/pedroteixeira/projects/ipfs/js-libp2p-websocket-star-rendezvous/node_modules/socket.io/lib/socket.js:513:12
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```

This fixes it.

2) When using a public rendez-vous point, sometimes a node got an invalid peer address (without the TCP part), which was causing the `utils.cleanUrlSIO()` call to throw. This catches this error, passing it into the `.dial()` callback.