### PR TITLE
Readme: fix rendezvous server usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,16 +116,16 @@ hello from the other side
 
 ## Usage
 
-To reduce dependencies `libp2p-websocket-star` comes without the rendezvous server, that means that you need to install `libp2p-websocket-star-rendezvous` to start a rendezvous server. To do that, first insall the module globally in your machine with:
+To reduce dependencies `libp2p-websocket-star` comes without the rendezvous server, that means that you need to install `libp2p-websocket-star-rendezvous` to start a rendezvous server. To do that, first install the module globally in your machine with:
 
 ```bash
 > npm install --global libp2p-websocket-star-rendezvous
 ```
 
-This will install a `websockets-star` CLI tool. Now you can spawn the server with:
+This will install a `rendezvous` CLI tool. Now you can spawn the server with:
 
 ```bash
-> websockets-star --port=9090 --host=127.0.0.1
+> rendezvous --port=9090 --host=127.0.0.1
 ```
 
 Defaults:


### PR DESCRIPTION
It took me some time to figure out the actual name for the installed module, then I found this: https://github.com/libp2p/js-libp2p-websocket-star-rendezvous/commit/5a2ce873096ff02ec2bdbde2fb1472374f43b601

Quick question: how can I execute the rendezvous server for `https`?