### PR TITLE
fix: debug log error

### DIFF
--- a/src/listener.js
+++ b/src/listener.js
@@ -214,9 +214,8 @@ class Listener extends EE {
       (cb) => this._crypto(cb)
     ], (err) => {
       if (err) {
-        this.log('success', err)
+        this.log('error', err)
         if (!(err instanceof Error)) err = new Error(err)
-        log(err)
         this._down()
         this.emit('error', err)
         this.emit('close')


### PR DESCRIPTION
Stumbled upon this when  debugging `js-ipfs`, it should log `error` instead of  `success`. Also, it was logging the error twice.