### PR TITLE
feat: retrieve peers on connect

### DIFF
--- a/src/listener.js
+++ b/src/listener.js
@@ -148,12 +148,7 @@ class Listener extends EE {
     }
 
     if (this.signature) {
-      this._join((err, needNewChallenge, peers) => {
-        if (needNewChallenge) {
-          return this.cryptoChallenge(cb)
-        }
-        cb(err, null, peers)
-      })
+      this._join(cb)
     } else {
       this._cryptoChallenge(cb)
     }

--- a/test/dial.spec.js
+++ b/test/dial.spec.js
@@ -100,16 +100,26 @@ describe('dial', () => {
     ws1.dial(ma2, (err, conn) => {
       expect(err).to.not.exist()
 
+      let endFn
+      let ended = false
       pull(
-        (end, cb) => {},
+        // Prevent end until test has completed
+        (end, cb) => {
+          endFn = cb
+        },
         conn,
         pull.drain(() => {
-          expect('Stream should never end').to.not.exist()
+          // Should not be called until test has completed
+          ended = true
         })
       )
 
       listeners[0].close(() => {})
-      listeners[0].listen(ma1, done)
+      listeners[0].listen(ma1, () => {
+        expect(ended).to.be.equal(false)
+        endFn(true)
+        done()
+      })
     })
   })
 

--- a/test/discovery.spec.js
+++ b/test/discovery.spec.js
@@ -8,16 +8,46 @@ const expect = chai.expect
 chai.use(dirtyChai)
 const multiaddr = require('multiaddr')
 const each = require('async/each')
+const series = require('async/series')
+const parallel = require('async/parallel')
+const rendezvous = require('libp2p-websocket-star-rendezvous')
 
 const WebSocketStar = require('../src')
 
 describe('peer discovery', () => {
   let listeners = []
   let ws1
-  const ma1 = multiaddr('/ip4/127.0.0.1/tcp/15001/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo3A')
-
+  const ma1 = multiaddr('/ip4/127.0.0.1/tcp/16001/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo4A')
   let ws2
-  const ma2 = multiaddr('/ip4/127.0.0.1/tcp/15003/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo3B')
+  const ma2 = multiaddr('/ip4/127.0.0.1/tcp/16002/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo4B')
+  let ws3
+  const ma3 = multiaddr('/ip4/127.0.0.1/tcp/16002/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo4C')
+
+  const _r = []
+  before((done) => {
+    const base = (v) => Object.assign({
+      host: '0.0.0.0',
+      cryptoChallenge: false,
+      strictMultiaddr: false,
+      refreshPeerListIntervalMS: 1000
+    }, v)
+
+    parallel([['discovery r1', {port: 16001}], ['discovery r2', {port: 16002}]].map((v) => (cb) => {
+      rendezvous.start(base(v.pop()), (err, r) => {
+        if (err) { return cb(err) }
+        _r.push(r)
+        console.log('%s: %s', v.pop(), r.info.uri)
+        cb()
+      })
+    }), done)
+  })
+
+  after((done) => {
+    series([
+      cb => each(listeners, (l, next) => l.close(next), cb),
+      cb => each(_r, (r, next) => r.stop(next), cb)
+    ], done)
+  })
 
   it('listen on the first', (done) => {
     ws1 = new WebSocketStar({ allowJoinWithDisabledChallenge: true })
@@ -45,7 +75,34 @@ describe('peer discovery', () => {
     listener.listen(ma2, (err) => {
       expect(err).to.not.exist()
     })
-  }).timeout(5000)
+  })
 
-  after(done => each(listeners, (l, next) => l.close(next), done))
+  it('new peer receives peer events for all other peers on connect', (done) => {
+    ws3 = new WebSocketStar({ allowJoinWithDisabledChallenge: true })
+
+    const discovered = []
+    ws3.discovery.on('peer', (peerInfo) => {
+      discovered.push(peerInfo.multiaddrs)
+      if (discovered.length === 2) {
+        gotAllPeerEvents()
+      }
+    })
+
+    const gotAllPeerEvents = () => {
+      const allMas = new Set()
+      discovered.forEach(mas => {
+        mas.forEach(ma => allMas.add(ma.toString()))
+      })
+      expect(allMas.has(ma1.toString())).to.equal(true)
+      expect(allMas.has(ma2.toString())).to.equal(true)
+      done()
+    }
+
+    const listener = ws3.createListener((/* conn */) => {})
+
+    listeners.push(listener)
+    listener.listen(ma3, (err) => {
+      expect(err).to.not.exist()
+    })
+  })
 })

--- a/test/discovery.spec.js
+++ b/test/discovery.spec.js
@@ -8,46 +8,19 @@ const expect = chai.expect
 chai.use(dirtyChai)
 const multiaddr = require('multiaddr')
 const each = require('async/each')
-const series = require('async/series')
-const parallel = require('async/parallel')
-const rendezvous = require('libp2p-websocket-star-rendezvous')
 
 const WebSocketStar = require('../src')
 
 describe('peer discovery', () => {
   let listeners = []
   let ws1
-  const ma1 = multiaddr('/ip4/127.0.0.1/tcp/16001/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo4A')
+  const ma1 = multiaddr('/ip4/127.0.0.1/tcp/15001/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo4A')
   let ws2
-  const ma2 = multiaddr('/ip4/127.0.0.1/tcp/16002/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo4B')
+  const ma2 = multiaddr('/ip4/127.0.0.1/tcp/15002/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo4B')
   let ws3
-  const ma3 = multiaddr('/ip4/127.0.0.1/tcp/16002/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo4C')
+  const ma3 = multiaddr('/ip4/127.0.0.1/tcp/15002/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo4C')
 
-  const _r = []
-  before((done) => {
-    const base = (v) => Object.assign({
-      host: '0.0.0.0',
-      cryptoChallenge: false,
-      strictMultiaddr: false,
-      refreshPeerListIntervalMS: 1000
-    }, v)
-
-    parallel([['discovery r1', {port: 16001}], ['discovery r2', {port: 16002}]].map((v) => (cb) => {
-      rendezvous.start(base(v.pop()), (err, r) => {
-        if (err) { return cb(err) }
-        _r.push(r)
-        console.log('%s: %s', v.pop(), r.info.uri)
-        cb()
-      })
-    }), done)
-  })
-
-  after((done) => {
-    series([
-      cb => each(listeners, (l, next) => l.close(next), cb),
-      cb => each(_r, (r, next) => r.stop(next), cb)
-    ], done)
-  })
+  after(done => each(listeners, (l, next) => l.close(next), done))
 
   it('listen on the first', (done) => {
     ws1 = new WebSocketStar({ allowJoinWithDisabledChallenge: true })


### PR DESCRIPTION
Get peers from rendezvous server on connect, and emit a `peer` event for each one

Depends on https://github.com/libp2p/js-libp2p-websocket-star-rendezvous/pull/27
See https://github.com/ipfs-shipyard/peer-star-app/pull/75#issuecomment-441322075 for details