### PR TITLE
fix: remove dead code

### DIFF
--- a/src/listener.js
+++ b/src/listener.js
@@ -148,12 +148,7 @@ class Listener extends EE {
     }
 
     if (this.signature) {
-      this._join((err, needNewChallenge) => {
-        if (needNewChallenge) {
-          return this.cryptoChallenge(cb)
-        }
-        cb(err)
-      })
+      this._join(cb)
     } else {
       this._cryptoChallenge(cb)
     }


### PR DESCRIPTION
I noticed that on [this line](https://github.com/libp2p/js-libp2p-websocket-star/blob/master/src/listener.js#L153) we call
```Javascript
return this.cryptoChallenge(cb)
```
but I think that should be
```Javascript
return this._cryptoChallenge(cb)
```
(note the leading underscore)

While I was looking into how to fix it, I realized that I don't think it's possible to reach this piece of code anyway - if you call `ss-join` on the rendezvous server with a signature (instead of a public key), and there is no existing nonce for this address, the server will [call util.getIdAndValidate() with the signature](https://github.com/libp2p/js-libp2p-websocket-star-rendezvous/blob/master/src/routes.js#L112), which will return an error because it is expecting a public key (not a signature).