### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,16 +30,15 @@
     "class-is": "^1.1.0",
     "data-queue": "0.0.3",
     "debug": "^4.1.0",
-    "interface-connection": "~0.3.2",
+    "interface-connection": "~0.3.3",
     "libp2p-crypto": "~0.14.1",
-    "mafmt": "^6.0.2",
-    "merge-recursive": "0.0.3",
-    "multiaddr": "^5.0.2",
+    "mafmt": "^6.0.3",
+    "multiaddr": "^6.0.2",
     "once": "^1.4.0",
     "peer-id": "~0.12.0",
-    "peer-info": "~0.14.1",
+    "peer-info": "~0.15.0",
     "pull-stream": "^3.6.9",
-    "socket.io-client": "^2.1.1",
+    "socket.io-client": "^2.2.0",
     "socket.io-pull-stream": "~0.1.5",
     "uuid": "^3.3.2"
   },
@@ -47,10 +46,10 @@
     "test": "test"
   },
   "devDependencies": {
-    "aegir": "^17.1.1",
+    "aegir": "^18.0.2",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
-    "libp2p-websocket-star-rendezvous": "~0.2.4",
+    "libp2p-websocket-star-rendezvous": "~0.3.0",
     "lodash": "^4.17.11"
   },
   "repository": {


### PR DESCRIPTION
Tests seem to fail, could be because of newer `libp2p-websocket-star-rendezvous` module

Btw seems like merge-recursive is never used in this module, so I just dropped it.

Could also be `feat: Security`, at least in `npm audit`'s opinion ;)