### PR TITLE
test: fix discovery test

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "aegir": "^18.0.3",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
-    "libp2p-websocket-star-rendezvous": "~0.2.4",
+    "libp2p-websocket-star-rendezvous": "~0.3.0",
     "lodash": "^4.17.11"
   },
   "repository": {

--- a/test/discovery.spec.js
+++ b/test/discovery.spec.js
@@ -16,9 +16,9 @@ describe('peer discovery', () => {
   let ws1
   const ma1 = multiaddr('/ip4/127.0.0.1/tcp/15001/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo4A')
   let ws2
-  const ma2 = multiaddr('/ip4/127.0.0.1/tcp/15002/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo4B')
+  const ma2 = multiaddr('/ip4/127.0.0.1/tcp/15001/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo4B')
   let ws3
-  const ma3 = multiaddr('/ip4/127.0.0.1/tcp/15002/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo4C')
+  const ma3 = multiaddr('/ip4/127.0.0.1/tcp/15001/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo4C')
 
   after(done => each(listeners, (l, next) => l.close(next), done))
 


### PR DESCRIPTION
The discovery test was wrong. It was attempting to discovery peers across separate rendezvous servers, which isn't going to work. The reason it worked locally with the old rendezvous server was due to `this` being used incorrectly, you can see the fix [here](https://github.com/libp2p/js-libp2p-websocket-star-rendezvous/commit/c6a833e). With that fix, the peers listed is correctly limited to each respective server, which caused these tests to fail.

cc: @hugomrdias 