### PR TITLE
chore: add discourse badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: node_js
+cache: npm
+stages:
+  - check
+  - test
+  - cov
+
+node_js:
+  - '10'
+
+os:
+  - linux
+  - osx
+
+script: npx nyc -s npm run test:node -- --bail
+after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov
+
+jobs:
+  include:
+    - stage: check
+      script:
+        - npx aegir commitlint --travis
+        - npx aegir dep-check -- -i wrtc -i electron-webrtc
+        - npm run lint
+
+    - stage: test
+      name: chrome
+      addons:
+        chrome: stable
+      script:
+        - npx aegir test -t browser
+
+    - stage: test
+      name: firefox
+      addons:
+        firefox: latest
+      script:
+        - npx aegir test -t browser -- --browsers FirefoxHeadless
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # libp2p-websocket-star
 
-[![](https://img.shields.io/badge/made%20by-mkg20001-blue.svg?style=flat-square)](http://ipn.io)
-[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
-[![Travis](https://travis-ci.org/libp2p/js-libp2p-websocket-star.svg?style=flat-square)](https://travis-ci.org/libp2p/js-libp2p-websocket-star)
-[![Circle](https://circleci.com/gh/libp2p/js-libp2p-websocket-star.svg?style=svg)](https://circleci.com/gh/libp2p/js-libp2p-websocket-star)
-[![Coverage](https://coveralls.io/repos/github/libp2p/js-libp2p-websocket-star/badge.svg?branch=master)](https://coveralls.io/github/libp2p/js-libp2p-websocket-star?branch=master)
-[![david-dm](https://david-dm.org/libp2p/js-libp2p-websocket-star.svg?style=flat-square)](https://david-dm.org/libp2p/js-libp2p-websocket-star)
+[![](https://img.shields.io/badge/made%20by-mkg20001-blue.svg?style=flat-square)](http://protocol.ai)
+[![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
+[![](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
+[![Discourse posts](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg)](https://discuss.libp2p.io)
+[![](https://img.shields.io/codecov/c/github/libp2p/js-libp2p-websocket-star.svg?style=flat-square)](https://codecov.io/gh/libp2p/js-libp2p-websocket-star)
+[![](https://img.shields.io/travis/libp2p/js-libp2p-websocket-star.svg?style=flat-square)](https://travis-ci.com/libp2p/js-libp2p-websocket-star)
+[![Dependency Status](https://david-dm.org/libp2p/js-libp2p-websocket-star.svg?style=flat-square)](https://david-dm.org/libp2p/js-libp2p-websocket-star)
+[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/feross/standard)
 
 [![](https://raw.githubusercontent.com/libp2p/interface-transport/master/img/badge.png)](https://github.com/libp2p/interface-transport)
 [![](https://raw.githubusercontent.com/libp2p/interface-connection/master/img/badge.png)](https://github.com/libp2p/interface-connection)

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,2 +1,0 @@
-// Warning: This file is automatically synced from https://github.com/ipfs/ci-sync so if you want to change it, please change it there and ask someone to sync all repositories.
-javascript()

--- a/package.json
+++ b/package.json
@@ -26,27 +26,29 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "async": "^2.6.1",
+    "async": "^2.6.2",
     "class-is": "^1.1.0",
     "debug": "^4.1.1",
-    "interface-connection": "~0.3.2",
-    "libp2p-crypto": "~0.16.0",
-    "mafmt": "^6.0.4",
-    "multiaddr": "^6.0.3",
-    "nanoid": "^2.0.0",
+    "interface-connection": "~0.3.3",
+    "libp2p-crypto": "~0.16.1",
+    "mafmt": "^6.0.7",
+    "multiaddr": "^6.0.6",
+    "nanoid": "^2.0.1",
     "once": "^1.4.0",
     "peer-id": "~0.12.2",
     "peer-info": "~0.15.1",
     "pull-stream": "^3.6.9",
+    "safe-buffer": "^5.1.2",
     "socket.io-client": "^2.1.1",
-    "socket.io-pull-stream": "~0.1.5"
+    "socket.io-pull-stream": "~0.1.5",
+    "uuid": "^3.3.2"
   },
   "files": [
     "src",
     "dist"
   ],
   "devDependencies": {
-    "aegir": "^18.0.3",
+    "aegir": "^18.2.2",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "libp2p-websocket-star-rendezvous": "~0.3.0",


### PR DESCRIPTION
In the context of [libp2p/libp2p#74](https://github.com/libp2p/libp2p/issues/74), the badge for [discuss.libp2p.io](http://discuss.libp2p.io) was added.

Dependencies were also updated and `travis` CI added.