### PR TITLE
chore: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+⛔️ DEPRECATED: libp2p-websocket-star is not supported anymore from [libp2p@0.27.0](https://github.com/libp2p/js-libp2p/releases/tag/v0.27.0). Check [js-libp2p/doc/CONFIGURATION.md](https://github.com/libp2p/js-libp2p/blob/master/doc/CONFIGURATION.md) for what modules are currently supported.
+
 # libp2p-websocket-star
 
 [![](https://img.shields.io/badge/made%20by-mkg20001-blue.svg?style=flat-square)](http://protocol.ai)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-⛔️ DEPRECATED: libp2p-websocket-star is not supported anymore from [libp2p@0.27.0](https://github.com/libp2p/js-libp2p/releases/tag/v0.27.0). Check [js-libp2p/doc/CONFIGURATION.md](https://github.com/libp2p/js-libp2p/blob/master/doc/CONFIGURATION.md) for what modules are currently supported.
+# ⛔️ DEPRECATED
+
+libp2p-websocket-star is not supported anymore from [libp2p@0.27.0](https://github.com/libp2p/js-libp2p/releases/tag/v0.27.0).  
+Check [js-libp2p/doc/CONFIGURATION.md](https://github.com/libp2p/js-libp2p/blob/master/doc/CONFIGURATION.md) for what modules are currently supported.
+
+_This library will not be maintained._
+
+---
 
 # libp2p-websocket-star
 


### PR DESCRIPTION
In the context of the async refactor in [libp2p@0.27.0](https://github.com/libp2p/js-libp2p/releases/tag/v0.27.0), this modules is being deprecated.
For immediate alternatives, you should use [libp2p/js-libp2p-webrtc-star](https://github.com/libp2p/js-libp2p-webrtc-star). Meanwhile, you should follow [libp2p/js-libp2p#385](https://github.com/libp2p/js-libp2p/issues/385), as I am currently working on this vertical.

Needs:

- [x]  npm deprecation notice

After merged, the repo must be archived